### PR TITLE
Moves meta and links from App head to template html head

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,31 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="theme-color" content="#111" />    
+    <meta name="theme-color" content="#111" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="favicon.ico" type="image/x-icon" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="true" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Alexandria&family=Noto+Sans&family=Nunito+Sans:wght@300;500&display=swap"
+      rel="stylesheet"
+    />
     <title>Jose Barrientos</title>
+    <meta
+      name="description"
+      content="C'est moi! classicalJo, currently crafting cascades of code at Scalemote as a Chapter Lead. With creativity, charisma and curiousity, I connect and collaborate with my crew to create cutting-edge applications. Currently working with React, Svelte, Nest and Typescript."
+    />
+    <meta property="og:title" content="Jose Barrientos" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://classicaljo.github.io/portfolio" />
+    <meta
+      property="og:image"
+      content="https://user-images.githubusercontent.com/55909151/278907201-eaf35df1-3537-42d5-84cd-87b94785edfc.png"
+    />
+    <meta
+      property="og:description"
+      content="C'est moi! classicalJo, currently crafting cascades of code at Scalemote as a Chapter Lead. With creativity, charisma and curiousity, I connect and collaborate with my crew to create cutting-edge applications. Currently working with React, Svelte, Nest and Typescript."
+    />
   </head>
   <body>
     <div id="app"></div>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -14,35 +14,6 @@
   setContext(sectionKey, createCurrentSection())
 </script>
 
-<svelte:head>
-  <meta charset="UTF-8" />
-  <meta name="theme-color" content="#111" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="icon" href="/favicon.ico" type="image/x-icon" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="true" />
-  <link
-    href="https://fonts.googleapis.com/css2?family=Alexandria&family=Noto+Sans&family=Nunito+Sans:wght@300;500&display=swap"
-    rel="stylesheet"
-  />
-  <title>Jose Barrientos</title>
-  <meta
-    name="description"
-    content="C'est moi! classicalJo, currently crafting cascades of code at Scalemote as a Chapter Lead. With creativity, charisma and curiousity, I connect and collaborate with my crew to create cutting-edge applications. Currently working with React, Svelte, Nest and Typescript."
-  />
-  <meta property="og:title" content="Jose Barrientos" />
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://classicaljo.github.io/portfolio" />
-  <meta
-    property="og:image"
-    content="https://user-images.githubusercontent.com/55909151/278907201-eaf35df1-3537-42d5-84cd-87b94785edfc.png"
-  />
-  <meta
-    property="og:description"
-    content="C'est moi! classicalJo, currently crafting cascades of code at Scalemote as a Chapter Lead. With creativity, charisma and curiousity, I connect and collaborate with my crew to create cutting-edge applications. Currently working with React, Svelte, Nest and Typescript."
-  />
-</svelte:head>
-
 <main>
   <Background />
   <Header />


### PR DESCRIPTION
# Summary

Due to svelte:head not working as expected, i moved back the meta tags, descriptos and favicon back to the index.html template