### PR TITLE
Updates og:image to better fit facebook and linkedin

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     <meta property="og:url" content="https://classicaljo.github.io/portfolio" />
     <meta
       property="og:image"
-      content="https://user-images.githubusercontent.com/55909151/278907201-eaf35df1-3537-42d5-84cd-87b94785edfc.png"
+      content="https://user-images.githubusercontent.com/55909151/278914077-7722d4b7-9619-4f56-ab4d-b0f1daa29723.png"
     />
     <meta
       property="og:description"


### PR DESCRIPTION
# Summary

Linkedin and facebook og:images were cropping on the sides. Updated pic, reuploaded to issues and updated the link on template.