### PR TITLE
Removes overlay image mask 

### DIFF
--- a/src/projects/Item.svelte
+++ b/src/projects/Item.svelte
@@ -66,7 +66,6 @@
     background: rgba(9, 0, 19, 0.75);
     z-index: 2;
     opacity: 1;
-    mask-image: url('../assets/images/aerolab.webp');
   }
   .overlay:hover,
   .overlay:active {


### PR DESCRIPTION
# Summary
The overlay incorrectly had an overlay mask that worked only for the first project. Removed it due to not being correctly applied to the other project images.